### PR TITLE
[Feature] List multiple HN posts

### DIFF
--- a/src/_constants.ts
+++ b/src/_constants.ts
@@ -15,6 +15,7 @@ export const RFC = {
 
 export const DEFAULT_SETTINGS: HackerNewsSettings = {
     defaultRefreshInterval: "60",
+    defaultNumStories: "10",
     storiesFolder: "HackerNews",
     storyTemplate: `---
 date: {{date}}

--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -14,7 +14,7 @@ export default class APIManager {
         this.plugin = plugin;
     }
 
-    public async requestTopHN(): Promise<HNItem> {
+    public async requestTopHN(): Promise<Array<HNItem>> {
         let itemIds: Array<Number>;
         try {
             const url = "https://hacker-news.firebaseio.com/v0/topstories.json";
@@ -24,11 +24,16 @@ export default class APIManager {
             return Promise.reject(error);
         }
 
-        const itemId = itemIds[Math.floor(Math.random() * itemIds.slice(0, 25).length)]
-        const itemResponse = await fetch(`https://hacker-news.firebaseio.com/v0/item/${itemId}.json?print=pretty`);
-        const hnItem = (await itemResponse.json()) as HNItem
 
-        return hnItem;
+        let hnItems: Array<HNItem> = [];
+        let numStories = parseInt(this.plugin.settings.defaultNumStories);
+        for (let i = 0; i < numStories; i++) {
+            var itemId = itemIds[Math.floor(Math.random() * itemIds.slice(0, 25).length)]
+            const itemResponse = await fetch(`https://hacker-news.firebaseio.com/v0/item/${itemId}.json?print=pretty`);
+            hnItems.push((await itemResponse.json()) as HNItem);
+        }
+
+        return hnItems;
     }
 
     public async saveHNItem(hnItem: HNItem) {

--- a/src/l10n/locale/en.ts
+++ b/src/l10n/locale/en.ts
@@ -12,6 +12,8 @@ export default {
     'The folder that holds the saved HackerNews stories. The folder will be created if it does not exist.': 'The folder that holds the saved HackerNews stories. The folder will be created if it does not exist.',
     'Story Template': 'Story Template',
     'Specify how the HackerNews story is saved; available attributes: title, url, date.': 'Specify how the HackerNews story is saved; available attributes: title, url, date.',
+    'Number of Stories': 'Number of Stories',
+    'The number of top stories to fetch from HackerNews. Default and invalid values will be reverted to 10.': 'The number of top stories to fetch from HackerNews. Default and invalid values will be reverted to 10.',
     'Donate': 'Donate',
     'If you found this plugin helpful, consider donating to support continued development.': 'If you found this plugin helpful, consider donating to support continued development.',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface HackerNewsSettings {
 	defaultRefreshInterval: string;
+	defaultNumStories: string;
 	storiesFolder: string;
 	storyTemplate: string;
 }

--- a/src/ui/hackernews/hackernewsView.svelte
+++ b/src/ui/hackernews/hackernewsView.svelte
@@ -13,7 +13,6 @@
     dataHN = await manager.requestTopHN();
   }
 
-  // TODO
   export async function saveHNItem(itemHN: HNItem) {
     console.log(`saving story ${itemHN.title}`);
     await manager.saveHNItem(itemHN);

--- a/src/ui/hackernews/hackernewsView.svelte
+++ b/src/ui/hackernews/hackernewsView.svelte
@@ -6,16 +6,17 @@
   export let manager: APIManager;
   export let refreshInterval: string;
 
-  let dataHN: HNItem;
+  let dataHN: Array<HNItem>;
 
   export async function fetchTopHN() {
-    console.log('fetching top story from HackerNews');
+    console.log('fetching top stories from HackerNews');
     dataHN = await manager.requestTopHN();
   }
 
-  export async function saveHNItem() {
-    console.log(`saving story ${dataHN.title}`);
-    await manager.saveHNItem(dataHN);
+  // TODO
+  export async function saveHNItem(itemHN: HNItem) {
+    console.log(`saving story ${itemHN.title}`);
+    await manager.saveHNItem(itemHN);
   }
 
   addEventListener("obsidian-hackernews-fetchTopHN", fetchTopHN);
@@ -26,20 +27,22 @@
 </script>
 
 <div class="main">
-  {#if dataHN}
+  <p class="hn-meta">
+    Refreshes every { refreshInterval } seconds.
+  </p>
+  {#if dataHN }
     <div class="results">
-      <div class="container">
-        <a href="{ dataHN.url }" target="_blank" class="hn-link">{ dataHN.title }</a>
-        <br />
-        <p class="hn-read">
-          <a href="/" on:click={saveHNItem}>Save</a>
-          •
-          <a href="{ dataHN.url }" target="_blank">Read now</a>
-        </p>
-        <p class="hn-meta">
-          Refreshes every { refreshInterval } seconds.
-        </p>
-      </div>
+      {#each dataHN as itemHN }
+        <div class="container">
+          <a href="{ itemHN.url }" target="_blank" class="hn-link">{ itemHN.title }</a>
+          <br />
+          <p class="hn-read">
+            <a href="/" on:click={saveHNItem(itemHN)}>Save</a>
+            •
+            <a href="{ itemHN.url }" target="_blank">Read now</a>
+          </p>
+        </div>
+      {/each}
     </div>
   {/if}
 </div>

--- a/src/ui/hackernews/hackernewsView.ts
+++ b/src/ui/hackernews/hackernewsView.ts
@@ -40,6 +40,7 @@ export default class HackerNewsView extends ItemView {
         });
         this._view.$set({
             refreshInterval: this.plugin.settings.defaultRefreshInterval,
+            numStories: this.plugin.settings.defaultNumStories,
         });
         return super.onOpen();
     }

--- a/src/ui/settings/settingsTab.ts
+++ b/src/ui/settings/settingsTab.ts
@@ -51,6 +51,18 @@ export default class SettingsTab extends PluginSettingTab {
                     await this.save();
                 }));
         new Setting(containerEl)
+            .setName(t('Number of Stories'))
+            .setDesc(t('The number of top stories to fetch from HackerNews. Default and invalid values will be reverted to 10.'))
+            .addText(text => text
+                .setPlaceholder('10')
+                .setValue(plugin.settings.defaultNumStories)
+                .onChange(async (value) => {
+                    let numStories = parseInt(value)
+                    if (Number.isNaN(numStories) || numStories <= 0) { numStories = 10 }
+                    plugin.settings.defaultNumStories = `${numStories}`;
+                    await this.save();
+                }));
+        new Setting(containerEl)
             .setName(t('Donate'))
             .setDesc(t('If you found this plugin helpful, consider donating to support continued development.'))
             .setClass("extra")


### PR DESCRIPTION
## Describe your changes
Fetch and display **multiple posts** from HN, similar to what has been proposed in #3. The number of posts to fetch can be selected in the plugin's settings via the `Number of Stories` field, the default is 10. Each post can be opened and saved as expected. The posts are taken randomly from the top stories.

I tested the build locally with `npm run build` and `npm run dev` on a linux machine.